### PR TITLE
Explode pipe-delimited conformance pack/standard values into individu…

### DIFF
--- a/cloudformation/cid-crcd-resources.yaml
+++ b/cloudformation/cid-crcd-resources.yaml
@@ -1499,18 +1499,21 @@ Resources:
               writer = csv.writer(output)
 
               # Write header
-              writer.writerow(['rule_name', 'source_identifier', 'conformance_packs', 'standards', 'sync_timestamp'])
+              writer.writerow(['rule_name', 'source_identifier', 'conformance_pack', 'standard', 'sync_timestamp'])
 
-              # Write data
+              # Write data - one row per conformance pack association
               sync_timestamp = datetime.utcnow().isoformat()
               for rule in rules:
-                  writer.writerow([
-                      rule['rule_name'],
-                      rule['source_identifier'],
-                      '|'.join(rule['conformance_packs']),
-                      '|'.join(rule['standards']),
-                      sync_timestamp
-                  ])
+                  packs = rule['conformance_packs'] if rule['conformance_packs'] else ['']
+                  stds = rule['standards'] if rule['standards'] else ['']
+                  for i in range(max(len(packs), len(stds))):
+                      writer.writerow([
+                          rule['rule_name'],
+                          rule['source_identifier'],
+                          packs[i] if i < len(packs) else '',
+                          stds[i] if i < len(stds) else '',
+                          sync_timestamp
+                      ])
 
               # Upload to S3
               s3.put_object(
@@ -1664,12 +1667,12 @@ Resources:
             - Name: source_identifier
               Type: string
               Comment: "AWS managed rule source identifier (e.g., ACCESS_KEYS_ROTATED)"
-            - Name: conformance_packs
+            - Name: conformance_pack
               Type: string
-              Comment: "Pipe-delimited list of conformance packs containing this rule"
-            - Name: standards
+              Comment: "Conformance pack containing this rule"
+            - Name: standard
               Type: string
-              Comment: "Pipe-delimited list of compliance standards"
+              Comment: "Compliance standard associated with the conformance pack"
             - Name: sync_timestamp
               Type: string
               Comment: "Timestamp when this rule was synced from GitHub"

--- a/dashboard_template/cid-crcd.yaml
+++ b/dashboard_template/cid-crcd.yaml
@@ -2242,8 +2242,8 @@ views:
           SELECT
             rule_name
           , source_identifier
-          , conformance_packs
-          , standards
+          , conformance_pack
+          , standard
           , sync_timestamp
           FROM "${athena_database_name}"."required_rules_reference"
         ),
@@ -2254,8 +2254,8 @@ views:
           , ar.pk_account_region
           , r.rule_name AS required_rule_name
           , r.source_identifier
-          , r.conformance_packs
-          , r.standards
+          , r.conformance_pack
+          , r.standard
           FROM active_account_regions ar
           CROSS JOIN required r
         ),
@@ -2273,8 +2273,8 @@ views:
           , arr.pk_account_region
           , arr.required_rule_name
           , arr.source_identifier
-          , arr.conformance_packs
-          , arr.standards
+          , arr.conformance_pack
+          , arr.standard
           , CASE WHEN e.core_rule_name IS NULL THEN 'MISSING' ELSE 'ENABLED' END AS rule_status
           , e.core_rule_name AS enabled_rule_name
           FROM account_required_rules arr
@@ -2289,11 +2289,11 @@ views:
       , pk_account_region
       , required_rule_name AS rule_name
       , source_identifier
-      , conformance_packs
-      , standards
+      , conformance_pack
+      , standard
       , rule_status
       , CAST(current_timestamp AS timestamp) AS analysis_timestamp
-      , concat(concat(concat(accountid, '-'), region), concat('-', required_rule_name)) AS pk_missing_rule
+      , concat(concat(concat(concat(concat(accountid, '-'), region), '-'), required_rule_name), concat('-', conformance_pack)) AS pk_missing_rule
       FROM missing_analysis
       WHERE rule_status = 'MISSING'
 
@@ -2311,7 +2311,7 @@ views:
           FROM "${athena_database_name}"."config_enabled_rules"
         ),
         required_count AS (
-          SELECT COUNT(*) AS total_required_rules
+          SELECT COUNT(DISTINCT rule_name) AS total_required_rules
           FROM "${athena_database_name}"."required_rules_reference"
         ),
         enabled_per_account AS (


### PR DESCRIPTION
…al rows

Instead of storing all conformance packs and standards as pipe-delimited values in a single row, each conformance pack association is now written as its own row in the CSV. Updated Glue table columns, Athena views, and coverage query to handle the new schema correctly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
